### PR TITLE
Fix bug in bridge_sampler.rjags.

### DIFF
--- a/R/bridge_sampler.R
+++ b/R/bridge_sampler.R
@@ -517,8 +517,8 @@ bridge_sampler.rjags <- function(samples = NULL, log_posterior = NULL, ..., data
 
 
   # convert to mcmc.list
-  cn <- colnames(samples$BUGSoutput$sims.matrix)
   samples <- coda::as.mcmc(samples)
+  cn <- coda::varnames(samples)
   samples <- samples[,cn != "deviance", drop = FALSE]
 
   # run bridge sampling


### PR DESCRIPTION
When dropping deviance from the sampled values, the wrong column was removed due to mismatch between the variable names of the mcmc.list object and the column names of the original samples object.

See the JAGS forums for a reproducible example
https://sourceforge.net/p/mcmc-jags/discussion/610037/thread/8dd40f03ae/
