### PR TITLE
Parallelize sampling for gen_samples and q22 with multiple repetitions

### DIFF
--- a/R/bridge_sampler.R
+++ b/R/bridge_sampler.R
@@ -263,9 +263,10 @@ bridge_sampler.stanfit <- function(samples = NULL, stanfit_model = samples,
                                          param_types = rep("real", ncol(samples_4_fit)),
                                          transTypes = transTypes,
                                          repetitions = repetitions, cores = cores,
-                                         packages = "rstan", maxiter = maxiter, silent = silent,
-                                         verbose = verbose,
-                                         r0 = 0.5, tol1 = 1e-10, tol2 = 1e-4))
+                                         packages = c("rstan", "mvtnorm"), 
+                                         maxiter = maxiter, silent = silent,
+                                         verbose = verbose, r0 = 0.5, tol1 = 1e-10, 
+                                         tol2 = 1e-4))
   } else {
     bridge_output <- do.call(what = paste0(".bridge.sampler.", method),
                              args = list(samples_4_fit = samples_4_fit,
@@ -278,9 +279,10 @@ bridge_sampler.stanfit <- function(samples = NULL, stanfit_model = samples,
                                          transTypes = transTypes,
                                          repetitions = repetitions, varlist = "stanfit",
                                          envir = sys.frame(sys.nframe()),
-                                         cores = cores, packages = "rstan", maxiter = maxiter,
-                                         silent = silent, verbose = verbose,
-                                         r0 = 0.5, tol1 = 1e-10, tol2 = 1e-4))
+                                         cores = cores, packages = c("rstan", "mvtnorm"), 
+                                         maxiter = maxiter, silent = silent, 
+                                         verbose = verbose, r0 = 0.5, tol1 = 1e-10, 
+                                         tol2 = 1e-4))
   }
 
   return(bridge_output)
@@ -490,7 +492,7 @@ bridge_sampler.stanreg <-
       bridge_output <- bridge_sampler(samples = samples, log_posterior = .stan_log_posterior,
                                       data = list(stanfit = sf), lb = lb, ub = ub,
                                       repetitions = repetitions, method = method, cores = cores,
-                                      use_neff = use_neff, packages = "rstan",
+                                      use_neff = use_neff, packages = c("rstan", "mvtnorm"),
                                       maxiter = maxiter, silent = silent,
                                       verbose = verbose)
     } else {
@@ -500,7 +502,7 @@ bridge_sampler.stanreg <-
                                       repetitions = repetitions, varlist = "stanfit",
                                       envir = sys.frame(sys.nframe()), method = method,
                                       cores = cores, use_neff = use_neff,
-                                      packages = "rstan", maxiter = maxiter,
+                                      packages = c("rstan", "mvtnorm"), maxiter = maxiter,
                                       silent = silent, verbose = verbose)
     }
     return(bridge_output)

--- a/R/bridge_sampler_normal.R
+++ b/R/bridge_sampler_normal.R
@@ -38,17 +38,26 @@
 
   # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
   q12 <- dmvnorm(samples_4_iter, mean = m, sigma = V, log = TRUE)
-  gen_samples <- vector(mode = "list", length = repetitions)
-  q22 <- vector(mode = "list", length = repetitions)
-  for (i in seq_len(repetitions)) {
-    gen_samples[[i]] <- rmvnorm(n_post, mean = m, sigma = V)
-    colnames(gen_samples[[i]]) <- colnames(samples_4_iter)
-    q22[[i]] <- dmvnorm(gen_samples[[i]], mean = m, sigma = V, log = TRUE)
-  }
+  # gen_samples <- vector(mode = "list", length = repetitions)
+  # q22 <- vector(mode = "list", length = repetitions)
+  # for (i in seq_len(repetitions)) {
+  #   gen_samples[[i]] <- rmvnorm(n_post, mean = m, sigma = V)
+  #   colnames(gen_samples[[i]]) <- colnames(samples_4_iter)
+  #   q22[[i]] <- dmvnorm(gen_samples[[i]], mean = m, sigma = V, log = TRUE)
+  # }
 
   # evaluate log of likelihood times prior for posterior samples and generated samples
   q21 <- vector(mode = "list", length = repetitions)
   if (cores == 1) {
+    # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
+    gen_samples <- vector(mode = "list", length = repetitions)
+    q22 <- vector(mode = "list", length = repetitions)
+    for (i in seq_len(repetitions)) {
+      gen_samples[[i]] <- rmvnorm(n_post, mean = m, sigma = V)
+      colnames(gen_samples[[i]]) <- colnames(samples_4_iter)
+      q22[[i]] <- dmvnorm(gen_samples[[i]], mean = m, sigma = V, log = TRUE)
+    }
+    
     q11 <- apply(.invTransform2Real(samples_4_iter, lb, ub, param_types), 1, log_posterior,
                  data = data, ...) + .logJacobian(samples_4_iter, transTypes, lb, ub)
     for (i in seq_len(repetitions)) {
@@ -57,6 +66,17 @@
     }
   } else if (cores > 1) {
     if ( .Platform$OS.type == "unix") {
+      # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
+      gen_samples <- parallel::mclapply(seq_len(repetitions), FUN =
+                                        function(x) rmvnorm(n_post, mean = m, sigma = V),
+                                        mc.preschedule = FALSE,
+                                        mc.cores = cores)
+      sapply(seq_along(gen_samples), function(i) colnames(gen_samples[[i]]) <- colnames(samples_4_iter))
+      q22 <- parallel::mclapply(seq_along(gen_samples), FUN = 
+                                function(i) dmvnorm(gen_samples[[i]], mean = m, sigma = V, log = TRUE),
+                                mc.preschedule = FALSE,
+                                mc.cores = cores)
+      
       split1 <- .split_matrix(matrix=.invTransform2Real(samples_4_iter, lb, ub, param_types), cores=cores)
       q11 <- parallel::mclapply(split1, FUN =
                                   function(x) apply(x, 1, log_posterior, data = data, ...),
@@ -73,8 +93,21 @@
       }
     } else {
     cl <- parallel::makeCluster(cores, useXDR = FALSE)
+    on.exit(parallel::stopCluster(cl))
     sapply(packages, function(x) parallel::clusterCall(cl = cl, "require", package = x,
                                                        character.only = TRUE))
+    
+    # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
+    parallel::clusterExport(cl = cl, varlist = c("m", "V", "n_post"), envir = environment())
+    gen_samples <- parallel::clusterApplyLB(cl = cl, 
+                                            x = seq_len(repetitions), 
+                                            fun = function(i) rmvnorm(n_post, mean = m, sigma = V))
+    sapply(seq_along(gen_samples), function(i) colnames(gen_samples[[i]]) <- colnames(samples_4_iter))
+    parallel::clusterExport(cl = cl, varlist = "gen_samples", envir = environment())
+    q22 <- parallel::clusterApplyLB(cl = cl,
+                                    x = seq_along(gen_samples),
+                                    fun = function(i) dmvnorm(gen_samples[[i]], mean = m, sigma = V, log = TRUE))
+    
     parallel::clusterExport(cl = cl, varlist = varlist, envir = envir)
 
     if ( ! is.null(rcppFile)) {
@@ -91,7 +124,7 @@
       q21[[i]] <- parallel::parRapply(cl = cl, x = .invTransform2Real(gen_samples[[i]], lb, ub, param_types), log_posterior,
                                       data = data, ...) + .logJacobian(gen_samples[[i]], transTypes, lb, ub)
     }
-    parallel::stopCluster(cl)
+    # parallel::stopCluster(cl)
     }
   }
   if(verbose) {

--- a/R/bridge_sampler_normal.R
+++ b/R/bridge_sampler_normal.R
@@ -38,18 +38,8 @@
 
   # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
   q12 <- dmvnorm(samples_4_iter, mean = m, sigma = V, log = TRUE)
-  # gen_samples <- vector(mode = "list", length = repetitions)
-  # q22 <- vector(mode = "list", length = repetitions)
-  # for (i in seq_len(repetitions)) {
-  #   gen_samples[[i]] <- rmvnorm(n_post, mean = m, sigma = V)
-  #   colnames(gen_samples[[i]]) <- colnames(samples_4_iter)
-  #   q22[[i]] <- dmvnorm(gen_samples[[i]], mean = m, sigma = V, log = TRUE)
-  # }
-
-  # evaluate log of likelihood times prior for posterior samples and generated samples
-  q21 <- vector(mode = "list", length = repetitions)
-  if (cores == 1) {
-    # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
+  if (cores == 1 || repetitions == 1) {
+    # if cores > 1 and repetitions > 1 we do this below using parallelization
     gen_samples <- vector(mode = "list", length = repetitions)
     q22 <- vector(mode = "list", length = repetitions)
     for (i in seq_len(repetitions)) {
@@ -57,7 +47,11 @@
       colnames(gen_samples[[i]]) <- colnames(samples_4_iter)
       q22[[i]] <- dmvnorm(gen_samples[[i]], mean = m, sigma = V, log = TRUE)
     }
-    
+  }
+
+  # evaluate log of likelihood times prior for posterior samples and generated samples
+  q21 <- vector(mode = "list", length = repetitions)
+  if (cores == 1) {
     q11 <- apply(.invTransform2Real(samples_4_iter, lb, ub, param_types), 1, log_posterior,
                  data = data, ...) + .logJacobian(samples_4_iter, transTypes, lb, ub)
     for (i in seq_len(repetitions)) {
@@ -67,16 +61,18 @@
   } else if (cores > 1) {
     if ( .Platform$OS.type == "unix") {
       # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
-      gen_samples <- parallel::mclapply(seq_len(repetitions), FUN =
-                                        function(x) rmvnorm(n_post, mean = m, sigma = V),
-                                        mc.preschedule = FALSE,
-                                        mc.cores = cores)
-      sapply(seq_along(gen_samples), function(i) colnames(gen_samples[[i]]) <- colnames(samples_4_iter))
-      q22 <- parallel::mclapply(seq_along(gen_samples), FUN = 
-                                function(i) dmvnorm(gen_samples[[i]], mean = m, sigma = V, log = TRUE),
-                                mc.preschedule = FALSE,
-                                mc.cores = cores)
-      
+      if (repetitions > 1) {
+        gen_samples <- parallel::mclapply(seq_len(repetitions), FUN =
+                                          function(x) rmvnorm(n_post, mean = m, sigma = V),
+                                          mc.preschedule = FALSE,
+                                          mc.cores = cores)
+        sapply(seq_along(gen_samples), function(i) colnames(gen_samples[[i]]) <- colnames(samples_4_iter))
+        q22 <- parallel::mclapply(seq_along(gen_samples), FUN = 
+                                  function(i) dmvnorm(gen_samples[[i]], mean = m, sigma = V, log = TRUE),
+                                  mc.preschedule = FALSE,
+                                  mc.cores = cores)
+      }
+        
       split1 <- .split_matrix(matrix=.invTransform2Real(samples_4_iter, lb, ub, param_types), cores=cores)
       q11 <- parallel::mclapply(split1, FUN =
                                   function(x) apply(x, 1, log_posterior, data = data, ...),
@@ -97,17 +93,19 @@
     sapply(packages, function(x) parallel::clusterCall(cl = cl, "require", package = x,
                                                        character.only = TRUE))
     
-    # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
-    parallel::clusterExport(cl = cl, varlist = c("m", "V", "n_post"), envir = environment())
-    gen_samples <- parallel::clusterApplyLB(cl = cl, 
-                                            x = seq_len(repetitions), 
-                                            fun = function(i) rmvnorm(n_post, mean = m, sigma = V))
-    sapply(seq_along(gen_samples), function(i) colnames(gen_samples[[i]]) <- colnames(samples_4_iter))
-    parallel::clusterExport(cl = cl, varlist = "gen_samples", envir = environment())
-    q22 <- parallel::clusterApplyLB(cl = cl,
-                                    x = seq_along(gen_samples),
-                                    fun = function(i) dmvnorm(gen_samples[[i]], mean = m, sigma = V, log = TRUE))
-    
+    if (repetitions > 1) {
+      # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
+      parallel::clusterExport(cl = cl, varlist = c("m", "V", "n_post"), envir = environment())
+      gen_samples <- parallel::clusterApplyLB(cl = cl, 
+                                              x = seq_len(repetitions), 
+                                              fun = function(i) rmvnorm(n_post, mean = m, sigma = V))
+      sapply(seq_along(gen_samples), function(i) colnames(gen_samples[[i]]) <- colnames(samples_4_iter))
+      parallel::clusterExport(cl = cl, varlist = "gen_samples", envir = environment())
+      q22 <- parallel::clusterApplyLB(cl = cl,
+                                      x = seq_along(gen_samples),
+                                      fun = function(i) dmvnorm(gen_samples[[i]], mean = m, sigma = V, log = TRUE))
+    }
+      
     parallel::clusterExport(cl = cl, varlist = varlist, envir = envir)
 
     if ( ! is.null(rcppFile)) {

--- a/R/bridge_sampler_warp3.R
+++ b/R/bridge_sampler_warp3.R
@@ -82,10 +82,14 @@
         if ( .Platform$OS.type == "unix") {
       # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
       gen_samples <- parallel::mclapply(seq_len(repetitions), FUN =
-                                        function(x) rmvnorm(n_post, sigma = diag(ncol(samples_4_fit))))
+                                        function(x) rmvnorm(n_post, sigma = diag(ncol(samples_4_fit))),
+                                        mc.preschedule = FALSE,
+                                        mc.cores = cores)
       sapply(seq_along(gen_samples), function(i) colnames(gen_samples[[i]]) <- colnames(samples_4_iter))
       q22 <- parallel::mclapply(seq_along(gen_samples), FUN =
-                                function(i) dmvnorm(gen_samples[[i]], sigma = diag(ncol(samples_4_fit)), log = TRUE)
+                                function(i) dmvnorm(gen_samples[[i]], sigma = diag(ncol(samples_4_fit)), log = TRUE),
+                                mc.preschedule = FALSE,
+                                mc.cores = cores)
       
       split1a <- .split_matrix(matrix=.invTransform2Real(samples_4_iter, lb, ub, param_types), cores=cores)
       split1b <- .split_matrix(matrix=.invTransform2Real(

--- a/R/bridge_sampler_warp3.R
+++ b/R/bridge_sampler_warp3.R
@@ -81,8 +81,6 @@
   } else if (cores > 1) {
         if ( .Platform$OS.type == "unix") {
       # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
-      q22 <- vector(mode = "list", length = repetitions)
-      gen_samples <- vector(mode = "list", length = repetitions)
       gen_samples <- parallel::mclapply(seq_len(repetitions), FUN =
                                         function(x) rmvnorm(n_post, sigma = diag(ncol(samples_4_fit))))
       sapply(seq_along(gen_samples), function(i) colnames(gen_samples[[i]]) <- colnames(samples_4_iter))

--- a/R/bridge_sampler_warp3.R
+++ b/R/bridge_sampler_warp3.R
@@ -39,20 +39,28 @@
 
   # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
   q12 <- dmvnorm((samples_4_iter - matrix(m, nrow = n_post, ncol = length(m), byrow = TRUE)) %*%
-                   t(solve(L)), sigma = diag(ncol(samples_4_fit)), log = TRUE)
-  q22 <- vector(mode = "list", length = repetitions)
-  gen_samples <- vector(mode = "list", length = repetitions)
-  for (i in seq_len(repetitions)) {
-    gen_samples[[i]] <- rmvnorm(n_post, sigma = diag(ncol(samples_4_fit)))
-    colnames(gen_samples[[i]]) <- colnames(samples_4_iter)
-    q22[[i]] <- dmvnorm(gen_samples[[i]], sigma = diag(ncol(samples_4_fit)), log = TRUE)
-  }
+                    t(solve(L)), sigma = diag(ncol(samples_4_fit)), log = TRUE)
+  # q22 <- vector(mode = "list", length = repetitions)
+  # gen_samples <- vector(mode = "list", length = repetitions)
+  # for (i in seq_len(repetitions)) {
+  #   gen_samples[[i]] <- rmvnorm(n_post, sigma = diag(ncol(samples_4_fit)))
+  #   colnames(gen_samples[[i]]) <- colnames(samples_4_iter)
+  #   q22[[i]] <- dmvnorm(gen_samples[[i]], sigma = diag(ncol(samples_4_fit)), log = TRUE)
+  # }
 
   e <- as.brob( exp(1) )
-
+  
   # evaluate log of likelihood times prior for posterior samples and generated samples
   q21 <- vector(mode = "list", length = repetitions)
   if (cores == 1) {
+    # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
+    q22 <- vector(mode = "list", length = repetitions)
+    gen_samples <- vector(mode = "list", length = repetitions)
+    for (i in seq_len(repetitions)) {
+      gen_samples[[i]] <- rmvnorm(n_post, sigma = diag(ncol(samples_4_fit)))
+      colnames(gen_samples[[i]]) <- colnames(samples_4_iter)
+      q22[[i]] <- dmvnorm(gen_samples[[i]], sigma = diag(ncol(samples_4_fit)), log = TRUE)
+    }
 
     q11 <- log(e^(apply(.invTransform2Real(samples_4_iter, lb, ub, param_types), 1, log_posterior,
                         data = data,...) + .logJacobian(samples_4_iter, transTypes, lb, ub)) +
@@ -72,6 +80,15 @@
     }
   } else if (cores > 1) {
         if ( .Platform$OS.type == "unix") {
+      # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
+      q22 <- vector(mode = "list", length = repetitions)
+      gen_samples <- vector(mode = "list", length = repetitions)
+      gen_samples <- parallel::mclapply(seq_len(repetitions), FUN =
+                                        function(x) rmvnorm(n_post, sigma = diag(ncol(samples_4_fit))))
+      sapply(seq_along(gen_samples), function(i) colnames(gen_samples[[i]]) <- colnames(samples_4_iter))
+      q22 <- parallel::mclapply(seq_along(gen_samples), FUN =
+                                function(i) dmvnorm(gen_samples[[i]], sigma = diag(ncol(samples_4_fit)), log = TRUE)
+      
       split1a <- .split_matrix(matrix=.invTransform2Real(samples_4_iter, lb, ub, param_types), cores=cores)
       split1b <- .split_matrix(matrix=.invTransform2Real(
         matrix(2*m, nrow = n_post, ncol = length(m), byrow = TRUE) - samples_4_iter, lb, ub, param_types
@@ -113,9 +130,21 @@
                                          tmp_mat2, transTypes, lb, ub)))
       }
         } else {
+          # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
           cl <- parallel::makeCluster(cores, useXDR = FALSE)
+          on.exit(parallel::stopCluster(cl))
           sapply(packages, function(x) parallel::clusterCall(cl = cl, "require", package = x, character.only = TRUE))
-
+          
+          parallel::clusterExport(cl = cl, varlist = c("n_post", "samples_4_fit"), envir = environment())
+          gen_samples <- parallel::clusterApplyLB(cl = cl,
+                                                  x = seq_len(repetitions),
+                                                  fun = function(x) rmvnorm(n_post, sigma = diag(ncol(samples_4_fit))))
+          sapply(seq_along(gen_samples), function(i) colnames(gen_samples[[i]]) <- colnames(samples_4_iter))
+          parallel::clusterExport(cl = cl, varlist = "gen_samples", envir = environment())
+          q22 <- parallel::clusterApplyLB(cl = cl,
+                                          x = seq_along(gen_samples),
+                                          fun = function(i) dmvnorm(gen_samples[[i]], sigma = diag(ncol(samples_4_fit)), log = TRUE))
+          
           parallel::clusterExport(cl = cl, varlist = varlist, envir = envir)
 
           if ( ! is.null(rcppFile)) {
@@ -152,7 +181,7 @@
                             .logJacobian(matrix(m, nrow = n_post, ncol = length(m), byrow = TRUE) +
                                            gen_samples[[i]] %*% t(L), transTypes, lb, ub)))
           }
-          parallel::stopCluster(cl)
+          # parallel::stopCluster(cl)
         }
 
   }

--- a/R/bridge_sampler_warp3.R
+++ b/R/bridge_sampler_warp3.R
@@ -40,20 +40,8 @@
   # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
   q12 <- dmvnorm((samples_4_iter - matrix(m, nrow = n_post, ncol = length(m), byrow = TRUE)) %*%
                     t(solve(L)), sigma = diag(ncol(samples_4_fit)), log = TRUE)
-  # q22 <- vector(mode = "list", length = repetitions)
-  # gen_samples <- vector(mode = "list", length = repetitions)
-  # for (i in seq_len(repetitions)) {
-  #   gen_samples[[i]] <- rmvnorm(n_post, sigma = diag(ncol(samples_4_fit)))
-  #   colnames(gen_samples[[i]]) <- colnames(samples_4_iter)
-  #   q22[[i]] <- dmvnorm(gen_samples[[i]], sigma = diag(ncol(samples_4_fit)), log = TRUE)
-  # }
-
-  e <- as.brob( exp(1) )
-  
-  # evaluate log of likelihood times prior for posterior samples and generated samples
-  q21 <- vector(mode = "list", length = repetitions)
-  if (cores == 1) {
-    # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
+  if (cores == 1 || repetitions == 1) {
+    # if cores > 1 or repetitions > 1, we do this below using parallelization
     q22 <- vector(mode = "list", length = repetitions)
     gen_samples <- vector(mode = "list", length = repetitions)
     for (i in seq_len(repetitions)) {
@@ -61,7 +49,13 @@
       colnames(gen_samples[[i]]) <- colnames(samples_4_iter)
       q22[[i]] <- dmvnorm(gen_samples[[i]], sigma = diag(ncol(samples_4_fit)), log = TRUE)
     }
+  }
 
+  e <- as.brob( exp(1) )
+  
+  # evaluate log of likelihood times prior for posterior samples and generated samples
+  q21 <- vector(mode = "list", length = repetitions)
+  if (cores == 1) {
     q11 <- log(e^(apply(.invTransform2Real(samples_4_iter, lb, ub, param_types), 1, log_posterior,
                         data = data,...) + .logJacobian(samples_4_iter, transTypes, lb, ub)) +
                  e^(apply(.invTransform2Real(matrix(2*m, nrow = n_post, ncol = length(m), byrow = TRUE) -
@@ -80,17 +74,18 @@
     }
   } else if (cores > 1) {
         if ( .Platform$OS.type == "unix") {
-      # sample from multivariate normal distribution and evaluate for posterior samples and generated samples
-      gen_samples <- parallel::mclapply(seq_len(repetitions), FUN =
-                                        function(x) rmvnorm(n_post, sigma = diag(ncol(samples_4_fit))),
-                                        mc.preschedule = FALSE,
-                                        mc.cores = cores)
-      sapply(seq_along(gen_samples), function(i) colnames(gen_samples[[i]]) <- colnames(samples_4_iter))
-      q22 <- parallel::mclapply(seq_along(gen_samples), FUN =
-                                function(i) dmvnorm(gen_samples[[i]], sigma = diag(ncol(samples_4_fit)), log = TRUE),
-                                mc.preschedule = FALSE,
-                                mc.cores = cores)
-      
+      if (repetitions > 1) {
+        gen_samples <- parallel::mclapply(seq_len(repetitions), FUN =
+                                          function(x) rmvnorm(n_post, sigma = diag(ncol(samples_4_fit))),
+                                          mc.preschedule = FALSE,
+                                          mc.cores = cores)
+        sapply(seq_along(gen_samples), function(i) colnames(gen_samples[[i]]) <- colnames(samples_4_iter))
+        q22 <- parallel::mclapply(seq_along(gen_samples), FUN =
+                                  function(i) dmvnorm(gen_samples[[i]], sigma = diag(ncol(samples_4_fit)), log = TRUE),
+                                  mc.preschedule = FALSE,
+                                  mc.cores = cores)
+      }
+        
       split1a <- .split_matrix(matrix=.invTransform2Real(samples_4_iter, lb, ub, param_types), cores=cores)
       split1b <- .split_matrix(matrix=.invTransform2Real(
         matrix(2*m, nrow = n_post, ncol = length(m), byrow = TRUE) - samples_4_iter, lb, ub, param_types
@@ -137,16 +132,18 @@
           on.exit(parallel::stopCluster(cl))
           sapply(packages, function(x) parallel::clusterCall(cl = cl, "require", package = x, character.only = TRUE))
           
-          parallel::clusterExport(cl = cl, varlist = c("n_post", "samples_4_fit"), envir = environment())
-          gen_samples <- parallel::clusterApplyLB(cl = cl,
-                                                  x = seq_len(repetitions),
-                                                  fun = function(x) rmvnorm(n_post, sigma = diag(ncol(samples_4_fit))))
-          sapply(seq_along(gen_samples), function(i) colnames(gen_samples[[i]]) <- colnames(samples_4_iter))
-          parallel::clusterExport(cl = cl, varlist = "gen_samples", envir = environment())
-          q22 <- parallel::clusterApplyLB(cl = cl,
-                                          x = seq_along(gen_samples),
-                                          fun = function(i) dmvnorm(gen_samples[[i]], sigma = diag(ncol(samples_4_fit)), log = TRUE))
-          
+          if (repetitions > 1) {
+            parallel::clusterExport(cl = cl, varlist = c("n_post", "samples_4_fit"), envir = environment())
+            gen_samples <- parallel::clusterApplyLB(cl = cl,
+                                                    x = seq_len(repetitions),
+                                                    fun = function(x) rmvnorm(n_post, sigma = diag(ncol(samples_4_fit))))
+            sapply(seq_along(gen_samples), function(i) colnames(gen_samples[[i]]) <- colnames(samples_4_iter))
+            parallel::clusterExport(cl = cl, varlist = "gen_samples", envir = environment())
+            q22 <- parallel::clusterApplyLB(cl = cl,
+                                            x = seq_along(gen_samples),
+                                            fun = function(i) dmvnorm(gen_samples[[i]], sigma = diag(ncol(samples_4_fit)), log = TRUE))
+          }
+            
           parallel::clusterExport(cl = cl, varlist = varlist, envir = envir)
 
           if ( ! is.null(rcppFile)) {


### PR DESCRIPTION
Sampling from a multivariate normal distribution can take a long time. When running bridge sampling with multiple repetitions, sampling to construct `gen_samples` and `q22` currently takes place serially, even if cores > 1. This pull request modifies `bridge_sampler_normal.R` and `bridge_sample_warp3.R` to sample for these in parallel when repetitions > 1 (if cores is also >1).

Some preliminary testing indicated that this could potentially save a lot of time when running several repetitions. I used a brm fit with a fairly complex model fit using 20k samples/chain and 4 chains. Here's the model formula, in case it matters:
```r
RT ~ Verb.Type.N * Sentence.Voice.N + me(s.voice.log.odds, se.log.odds) +
    (1 + Verb.Type.N * Sentence.Voice.N + me(s.voice.log.odds, se.log.odds) | Subject) +
    (1 + Verb.Type.N * Sentence.Voice.N + me(s.voice.log.odds, se.log.odds) | Stimulus.Number)
```
I measured how long it took to run 4 repetitions of the bridge sampler (`method = "normal"`) using `Sys.time()`. The current serial implementation took 33.16 minutes, while the parallelized version 14.36 minutes, a difference of 18.8 minutes. I don't have local resources available to run many more repetitions than that with a model of this size, but I imagine it might scale nicely, since there's a noticeable time savings even with only 4 repetitions.

I will note that I ran this on Windows using `parallel::makeCluster` rather than `parallel::mclapply`, after bypassing the check against running multicore on Windows, so I'm not sure if that code works as is on Unix-based systems, nor do I have an estimate of the time savings on those systems—someone with a Unix-based system should do some testing if this change turns out to be of interest.

In addition, I don't know whether there is some potential concern about RNG seeding across the cores that might compromise the results; if so, then just eating the time cost for running multiple repetitions may be the way to go. If not though, parallelizing these draws might result in significant time savings for people running multiple repetitions.