### PR TITLE
Implement `posterior::ess_mean` with `coda` fallback (Issue #45) (#5)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,6 +45,7 @@ Suggests:
     rstanarm,
     nimble,
     MCMCpack,
+    posterior,
     cmdstanr (>= 0.6.0)
 Description: Provides functions for estimating marginal likelihoods, Bayes
     factors, posterior model probabilities, and normalizing constants in general,

--- a/R/bridge_sampler.R
+++ b/R/bridge_sampler.R
@@ -303,9 +303,10 @@ bridge_sampler.stanfit <- function(
   }
   samples_4_iter_tmp <- coda::as.mcmc.list(samples_4_iter_tmp)
 
+  samples_4_iter <- apply(samples_4_iter_stan, 1, rbind)
+
   ess <- .bs_compute_ess(samples_4_iter, use_ess)
 
-  samples_4_iter <- apply(samples_4_iter_stan, 1, rbind)
 
   parameters <- paste0("x", (seq_len(dim(upars)[1])))
 
@@ -429,11 +430,11 @@ bridge_sampler.mcmc.list <- function(
     function(x) .transform2Real(x, lb = lb, ub = ub)$theta_t
   )
 
-  # compute effective sample size
-  ess <- .bs_compute_ess(samples_4_iter, use_ess)
-
   # convert to matrix
   samples_4_iter <- do.call("rbind", samples_4_iter_tmp)
+
+  # compute effective sample size
+  ess <- .bs_compute_ess(samples_4_iter, use_ess)
 
   # run bridge sampling
   out <- do.call(

--- a/R/bridge_sampler.R
+++ b/R/bridge_sampler.R
@@ -33,17 +33,19 @@
 #'  \code{\link{.GlobalEnv}}. For other systems (e.g., Windows)
 #'  \code{\link{makeCluster}} is used and further arguments specified below will
 #'  be used.
-#'@param use_ess Logical. If \code{TRUE}, the effective sample size (compared
-#'  to the nominal sample size) is used in the optimal bridge function and in
-#'  the iterative scheme's uncertainty calculations (making MCSE computation
-#'  take into account autocorrelation in MCMC samples). Default is TRUE. If
-#'  FALSE, the nominal sample size  is used instead. If \code{samples} is a
-#'  \code{matrix}, it is assumed that the \code{matrix} contains the samples of
-#'  one chain in order. If \code{samples} come from more than one chain, we
-#'  recommend to use an \code{mcmc.list} object for optimal performance. By default 
-#'  this uses \code{posterior::ess_mean()} if the \pkg{posterior} package is
-#'  installed and the global option \code{bridgesampling.use_posterior_ess} is 
-#'  \code{TRUE}; otherwise it falls back to \code{coda::effectiveSize()}.
+#'@param use_ess Logical. If \code{TRUE} (default is \code{TRUE}), the effective 
+#'  sample size (compared to the nominal sample size) is used in the optimal
+#'  bridge function and in the iterative scheme's uncertainty calculations
+#'  (making MCSE computation take into account autocorrelation in MCMC samples).
+#'  If \code{FALSE}, the nominal sample size is used instead. If \code{samples}
+#'  is a \code{matrix}, it is assumed that the \code{matrix} contains the
+#'  samples of one chain in order. If \code{samples} come from more than one
+#'  chain, we recommend to use an \code{mcmc.list} object for optimal
+#'  performance. The ESS computation method is selected via the global option
+#'  \code{bridgesampling.ess_function}, which can be \code{"posterior"} (uses
+#'  \code{posterior::ess_mean()}) or \code{"coda"} (uses
+#'  \code{coda::effectiveSize()}). The package sets a default for this option
+#'  at load time depending on whether the \pkg{posterior} package is available.
 #'@param packages character vector with names of packages needed for evaluating
 #'  \code{log_posterior} in parallel (only relevant if \code{cores > 1} and
 #'  \code{.Platform$OS.type != "unix"}).

--- a/R/bridge_sampler_normal.R
+++ b/R/bridge_sampler_normal.R
@@ -5,7 +5,7 @@
   samples_4_iter, # matrix with already transformed samples for the
   # iterative scheme (rows are samples), colnames are "trans_x"
   # where x is the parameter name
-  neff, # effective sample size of samples_4_iter (i.e., already transformed samples), scalar
+  ess, # effective sample size of samples_4_iter (i.e., already transformed samples), scalar
   log_posterior,
   ...,
   data,
@@ -27,8 +27,8 @@
   tol1,
   tol2
 ) {
-  if (is.null(neff)) {
-    neff <- nrow(samples_4_iter)
+  if (is.null(ess)) {
+    ess <- nrow(samples_4_iter)
   }
 
   n_post <- nrow(samples_4_iter)
@@ -240,7 +240,7 @@
       silent = silent,
       use_ess = use_ess,
       criterion = "r",
-      neff = neff
+      ess = ess
     )
     if (is.na(tmp$logml) & !is.null(tmp$r_vals)) {
       warning(
@@ -263,7 +263,7 @@
         silent = silent,
         use_ess = use_ess,
         criterion = "logml",
-        neff = neff
+        ess = ess
       )
       tmp$niter <- maxiter + tmp$niter
     }

--- a/R/bridge_sampler_warp3.R
+++ b/R/bridge_sampler_warp3.R
@@ -5,7 +5,7 @@
   samples_4_iter, # matrix with already transformed samples for the
   # iterative scheme (rows are samples), colnames are "trans_x"
   # where x is the parameter name
-  neff, # effective sample size of samples_4_iter (i.e., already transformed samples), scalar
+  ess, # effective sample size of samples_4_iter (i.e., already transformed samples), scalar
   log_posterior,
   ...,
   data,
@@ -27,8 +27,8 @@
   tol1,
   tol2
 ) {
-  if (is.null(neff)) {
-    neff <- nrow(samples_4_iter)
+  if (is.null(ess)) {
+    ess <- nrow(samples_4_iter)
   }
 
   n_post <- nrow(samples_4_iter)
@@ -402,7 +402,7 @@
       maxiter = maxiter,
       silent = silent,
       criterion = "r",
-      neff = neff,
+      ess = ess,
       use_ess = use_ess
     )
     if (is.na(tmp$logml) & !is.null(tmp$r_vals)) {
@@ -425,7 +425,7 @@
         maxiter = maxiter,
         silent = silent,
         criterion = "logml",
-        neff = neff,
+        ess = ess,
         use_ess = use_ess
       )
       tmp$niter <- maxiter + tmp$niter

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,11 @@
+.onLoad <- function(libname, pkgname) {
+  if (requireNamespace("posterior", quietly = TRUE)) {
+    options(bridgesampling.ess_function = "posterior")
+  } else {
+    options(bridgesampling.ess_function = "coda")
+    packageStartupMessage(
+      "Package 'posterior' not found; defaulting to ESS via coda::effectiveSize(). ",
+      "Install 'posterior' to use posterior-based ESS."
+    )
+  }
+}

--- a/tests/testthat/test-bridge_sampler_CmdStanMCMC.R
+++ b/tests/testthat/test-bridge_sampler_CmdStanMCMC.R
@@ -50,7 +50,7 @@ testthat::test_that("bridge_sampler() works for CmdStanMCMC and basic sanity che
     show_exceptions = FALSE
   )
 
-  bs <- bridgesampling::bridge_sampler(fit, silent = TRUE, use_neff = FALSE)
+  bs <- bridgesampling::bridge_sampler(fit, silent = TRUE, use_ess = FALSE)
 
   testthat::expect_s3_class(fit, "CmdStanMCMC")
   testthat::expect_true(is.list(bs))
@@ -67,7 +67,7 @@ testthat::test_that("bridge_sampler() works for CmdStanMCMC and basic sanity che
     show_messages = FALSE,
     show_exceptions = FALSE
   )
-  bs2 <- bridgesampling::bridge_sampler(fit2, silent = TRUE, use_neff = FALSE)
+  bs2 <- bridgesampling::bridge_sampler(fit2, silent = TRUE, use_ess = FALSE)
   testthat::expect_true(is.finite(bs2$logml))
 })
 
@@ -120,7 +120,7 @@ testthat::test_that("CmdStanMCMC bridge estimate roughly agrees with rstan", {
     show_messages = FALSE,
     show_exceptions = FALSE
   )
-  bs_cmd <- bridgesampling::bridge_sampler(fit_cs, silent = TRUE, use_neff = FALSE)
+  bs_cmd <- bridgesampling::bridge_sampler(fit_cs, silent = TRUE, use_ess = FALSE)
   testthat::expect_true(is.finite(bs_cmd$logml))
 
   Sys.sleep(2.5)
@@ -130,7 +130,7 @@ testthat::test_that("CmdStanMCMC bridge estimate roughly agrees with rstan", {
     sm, data = data_list, seed = 777,
     chains = 4, iter = 10000, warmup = 3000, refresh = 0, cores = 2
   )
-  bs_rstan <- bridgesampling::bridge_sampler(fit_rs, silent = TRUE, use_neff = FALSE)
+  bs_rstan <- bridgesampling::bridge_sampler(fit_rs, silent = TRUE, use_ess = FALSE)
   testthat::expect_true(is.finite(bs_rstan$logml))
 
   # Compare the two bridge estimates. Tolerance accounts for MC/bridge variance.

--- a/tests/testthat/test-compute-ess.R
+++ b/tests/testthat/test-compute-ess.R
@@ -90,8 +90,8 @@ test_that("bridge_sampler runs with posterior-based ESS when available", {
     samples        = samples,
     log_posterior  = log_post,
     data           = x,
-    lb             = -Inf,
-    ub             = Inf,
+    lb             = c(theta = -Inf),
+    ub             = c(theta =  Inf),
     use_ess        = TRUE,
     method         = "normal",
     silent         = TRUE

--- a/tests/testthat/test-ess.R
+++ b/tests/testthat/test-ess.R
@@ -1,0 +1,78 @@
+test_that(".bs_compute_ess uses posterior when available and enabled", {
+  skip_if_not_installed("posterior")
+
+  set.seed(123)
+  # Simple correlated chain to make ESS less than n
+  draws <- cbind(theta = cumsum(rnorm(2000)))
+
+  fn <- getFromNamespace(".bs_compute_ess", "bridgesampling")
+
+  old_opts <- options(bridgesampling.use_posterior_ess = TRUE)
+  on.exit(options(old_opts), add = TRUE)
+
+  neff <- fn(draws, use_neff = TRUE)
+
+  posterior_draws <- posterior::as_draws_matrix(draws)
+  expected <- as.numeric(median(posterior::ess_mean(posterior_draws)))
+
+  expect_equal(neff, expected)
+})
+
+test_that(".bs_compute_ess falls back to coda when posterior is disabled", {
+  set.seed(123)
+  draws <- cbind(theta = cumsum(rnorm(2000)))
+
+  fn <- getFromNamespace(".bs_compute_ess", "bridgesampling")
+
+  old_opts <- options(bridgesampling.use_posterior_ess = FALSE)
+  on.exit(options(old_opts), add = TRUE)
+
+  neff <- fn(draws, use_neff = TRUE)
+
+  mcmc_obj <- coda::mcmc(draws)
+  expected <- as.numeric(median(coda::effectiveSize(mcmc_obj)))
+
+  expect_equal(neff, expected)
+})
+
+test_that(".bs_compute_ess returns n when use_neff = FALSE", {
+  set.seed(123)
+  draws <- cbind(theta = rnorm(100))
+
+  fn <- getFromNamespace(".bs_compute_ess", "bridgesampling")
+
+  neff <- fn(draws, use_neff = FALSE)
+
+  expect_identical(neff, nrow(draws))
+})
+
+test_that("bridge_sampler runs with posterior-based ESS when available", {
+  skip_if_not_installed("posterior")
+
+  set.seed(123)
+  x <- rnorm(100)
+
+  log_post <- function(theta, data) {
+    # Standard normal likelihood and prior, up to a constant
+    sum(dnorm(data, mean = theta, log = TRUE)) + dnorm(theta, log = TRUE)
+  }
+
+  samples <- matrix(rnorm(2000), ncol = 1)
+  colnames(samples) <- "theta"
+
+  old_opts <- options(bridgesampling.use_posterior_ess = TRUE)
+  on.exit(options(old_opts), add = TRUE)
+
+  fit <- bridge_sampler(
+    samples      = samples,
+    log_posterior = log_post,
+    data         = x,
+    lb           = -Inf,
+    ub           = Inf,
+    use_neff     = TRUE,
+    method       = "normal",
+    silent       = TRUE
+  )
+
+  expect_true(is.finite(logml(fit)))
+})

--- a/tests/testthat/test-iterative-scheme-mcse.R
+++ b/tests/testthat/test-iterative-scheme-mcse.R
@@ -22,7 +22,7 @@ test_that("MCSE is finite, positive, and returned for normal method", {
     maxiter = 1000,
     silent = TRUE,
     criterion = "r",
-    neff = length(q11),
+    ess = length(q11),
     use_ess = FALSE
   )
 
@@ -57,7 +57,7 @@ test_that("MCSE is invariant to constant shifts (warp3 vs normal)", {
     maxiter = 1000,
     silent = TRUE,
     criterion = "r",
-    neff = length(q11),
+    ess = length(q11),
     use_ess = FALSE
   )
 
@@ -73,7 +73,7 @@ test_that("MCSE is invariant to constant shifts (warp3 vs normal)", {
     maxiter = 1000,
     silent = TRUE,
     criterion = "r",
-    neff = length(q11),
+    ess = length(q11),
     use_ess = FALSE
   )
 
@@ -103,7 +103,7 @@ test_that("MCSE roughly scales like 1/sqrt(n)", {
     maxiter = 1000,
     silent = TRUE,
     criterion = "r",
-    neff = length(base_q11),
+    ess = length(base_q11),
     use_ess = FALSE
   )
 
@@ -121,7 +121,7 @@ test_that("MCSE roughly scales like 1/sqrt(n)", {
     maxiter = 1000,
     silent = TRUE,
     criterion = "r",
-    neff = length(base_q11) * k,
+    ess = length(base_q11) * k,
     use_ess = FALSE
   )
 
@@ -157,7 +157,7 @@ test_that("Function runs with use_ess = TRUE (if posterior installed)", {
     maxiter = 1000,
     silent = TRUE,
     criterion = "r",
-    neff = length(q11),
+    ess = length(q11),
     use_ess = TRUE
   )
 

--- a/tests/testthat/test-log_posterior_cmdstan.R
+++ b/tests/testthat/test-log_posterior_cmdstan.R
@@ -82,7 +82,7 @@ test_that(".cmdstan_log_posterior and bridge_sampler agree with analytical resul
     repetitions = 1,
     method      = "normal",
     cores       = 1L,
-    use_neff    = FALSE,
+    use_ess     = FALSE,
     silent      = TRUE,
     verbose     = FALSE
   )
@@ -211,7 +211,7 @@ test_that("bridgesampling and .cmdstan_log_posterior handle constrained paramete
     repetitions = 1,
     method      = "normal",
     cores       = 1L,
-    use_neff    = FALSE,
+    use_ess     = FALSE,
     silent      = TRUE,
     verbose     = FALSE
   )


### PR DESCRIPTION
As discussed in Issue #45, with the following, an internal helper, `.bs_compute_ess()` does the following to compute the effective sample size:

1. Tries `posterior::ess_mean()` if the package is installed and the global option `bridgesampling.use_posterior_ess` (default TRUE) is enabled.
2. Falls back silently to `median(coda::effectiveSize())`.
3. Falls back again to raw `nrow(samples)` if both methods fail.
4. Replaces existing ESS code paths with calls to the helper.
5. Includes some basic checks to ensure the internal function works as intended (`test_ess.R`)
6. Adds `posterior` to `Suggest:`

Additionally, it also renames all `use_neff` and `neff` with `use_ess` and `ess` respectively.